### PR TITLE
Adding --net-opts as a way to pass network options to network drivers

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -44,6 +44,8 @@ type EndpointSettings struct {
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
 	MacAddress          string
+	// List of network options set to this container
+	NetOpts             map[string]string
 }
 
 // NetworkingConfig represents the container's networking configuration for each of its interfaces

--- a/container/container.go
+++ b/container/container.go
@@ -813,6 +813,13 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 		for _, alias := range epConfig.Aliases {
 			createOptions = append(createOptions, libnetwork.CreateOptionMyAlias(alias))
 		}
+
+		// Passing network options to driver on EndpointCreate
+		for key, val := range epConfig.NetOpts {
+			genericOption := options.Generic{}
+			genericOption[key] = val
+			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
+		}
 	}
 
 	if container.NetworkSettings.Service != nil {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2371,7 +2371,7 @@ _docker_run() {
 		--memory-swappiness
 		--memory-reservation
 		--name
-        --net-opt
+        	--net-opt
 		--network
 		--network-alias
 		--oom-score-adj

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2371,7 +2371,7 @@ _docker_run() {
 		--memory-swappiness
 		--memory-reservation
 		--name
-        	--net-opt
+		--net-opt
 		--network
 		--network-alias
 		--oom-score-adj

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2371,6 +2371,7 @@ _docker_run() {
 		--memory-swappiness
 		--memory-reservation
 		--name
+        --net-opt
 		--network
 		--network-alias
 		--oom-score-adj

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -78,6 +78,7 @@ Options:
       --memory-swap string          Swap limit equal to memory plus swap: '-1' to enable unlimited swap
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1)
       --name string                 Assign a name to the container
+      --net-opt value               Network driver options (default [])
       --network-alias value         Add network-scoped alias for the container (default [])
       --network string              Connect a container to a network
                                     'bridge': create a network stack on the default Docker bridge

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -292,7 +292,7 @@ of the containers.
     --ip=""            : Sets the container's Ethernet device's IPv4 address
     --ip6=""           : Sets the container's Ethernet device's IPv6 address
     --link-local-ip=[] : Sets one or more container's Ethernet device's link local IPv4/IPv6 addresses
-    --net-opt=[] : Sets one or more option for the network driver
+    --net-opt=[]       : Sets one or more option for the network driver
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -292,6 +292,7 @@ of the containers.
     --ip=""            : Sets the container's Ethernet device's IPv4 address
     --ip6=""           : Sets the container's Ethernet device's IPv6 address
     --link-local-ip=[] : Sets one or more container's Ethernet device's link local IPv4/IPv6 addresses
+    --net-opt=[] : Sets one or more option for the network driver
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -54,6 +54,7 @@ docker-run - Run a command in a new container
 [**--memory-swap**[=*LIMIT*]]
 [**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
 [**--name**[=*NAME*]]
+[**--net-opt**[=*[]*]]
 [**--network-alias**[=*[]*]]
 [**--network**[=*"bridge"*]]
 [**--oom-kill-disable**]
@@ -386,6 +387,9 @@ to the container with **--name** then the daemon will also generate a random
 string name. The name is useful when defining links (see **--link**) (or any
 other place you need to identify a container). This works for both background
 and foreground Docker containers.
+
+**--net-opt**=[]
+  Network driver specific options.
 
 **--net**="*bridge*"
    Set the Network mode for the container

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -197,8 +197,8 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.Var(&copts.aliases, "net-alias", "Add network-scoped alias for the container")
 	flags.Var(&copts.aliases, "network-alias", "Add network-scoped alias for the container")
 	flags.MarkHidden("net-alias")
-        // Network driver specific options
-        flags.Var(&copts.netOpts, "net-opt", "Set network configuration option on a container")
+	// Network driver specific options
+	flags.Var(&copts.netOpts, "net-opt", "Set network configuration option on a container")
 
 	// Logging and storage
 	flags.StringVar(&copts.loggingDriver, "log-driver", "", "Logging driver for the container")

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -198,7 +198,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.Var(&copts.aliases, "network-alias", "Add network-scoped alias for the container")
 	flags.MarkHidden("net-alias")
 	// Network driver specific options
-	flags.Var(&copts.netOpts, "net-opt", "Set network configuration option on a container")
+	flags.Var(&copts.netOpts, "net-opt", "Set network driver option on a container")
 
 	// Logging and storage
 	flags.StringVar(&copts.loggingDriver, "log-driver", "", "Logging driver for the container")


### PR DESCRIPTION
The docker plugin model has made it easier to extend docker with custom drivers that can be maintained independently by third parties. However, as reported by issue [910](https://github.com/docker/libnetwork/issues/910) a way of passing arbitrary parameters from docker client to remote driver is needed. 

Many use cases require passing network configuration to a network driver that might vary from container to container and might only be known at container creation time. Examples are configuring the MTU or queue length of a NIC or passing ip aliases, routes or iptables rules for containers.

This patch proposes adding a new --net-opt option to docker to allow passing arbitrary information to network drivers, much like the --log-opt does. --net-opt options are used with docker run command and are directly copied to the container's NetworkSettings and then passed to the network driver on endpoint create.
