### PR TITLE
Support opening/closing luks encrypted ceph volumes

### DIFF
--- a/volume/ceph/ceph.go
+++ b/volume/ceph/ceph.go
@@ -2,6 +2,8 @@ package cephvolumedriver
 
 import (
 	"errors"
+	"io"
+	"path"
 	"sync"
 
 	"bytes"
@@ -15,7 +17,11 @@ import (
 	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
-const CephImageSizeMB = 1024 * 1024 // 1TB
+const (
+	CephImageSizeMB   = 1024 * 1024 // 1TB
+	LuksDevMapperPath = "/dev/mapper/"
+	criptoLUKS        = "crypto_LUKS"
+)
 
 func New() *Root {
 	return &Root{
@@ -39,9 +45,10 @@ func (r *Root) Create(name string, _ map[string]string) (volume.Volume, error) {
 	v, exists := r.volumes[name]
 	if !exists {
 		v = &Volume{
-			driverName:       r.Name(),
-			name:             name,
-			mappedDevicePath: "", // Will be set by Mount()
+			driverName:           r.Name(),
+			name:                 name,
+			mappedDevicePath:     "", // Will be set by Mount()
+			mappedLuksDevicePath: "", // Will be set by Mount()
 		}
 		r.volumes[name] = v
 	}
@@ -123,6 +130,8 @@ type Volume struct {
 	driverName string
 	// the path to the device to which the Ceph volume has been mapped
 	mappedDevicePath string
+	// the path to the LUKS folder to which the Ceph device has been mapped
+	mappedLuksDevicePath string
 }
 
 func (v *Volume) Name() string {
@@ -153,7 +162,7 @@ func (v *Volume) Mount(id string) (mappedDevicePath string, returnedError error)
 	cmd := exec.Command("rbd", "create", v.Name(), "--size", strconv.Itoa(CephImageSizeMB))
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err := cmd.Run();
+	err := cmd.Run()
 	if err == nil {
 		logrus.Infof("Created Ceph volume '%s'", v.Name())
 		v.mappedDevicePath, err = mapCephVolume(v.Name())
@@ -177,7 +186,37 @@ func (v *Volume) Mount(id string) (mappedDevicePath string, returnedError error)
 	if err != nil {
 		return "", err
 	}
+
+	if fsType == criptoLUKS {
+		cmd = exec.Command("cryptsetup", "luksOpen", v.mappedDevicePath, v.Name())
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			logrus.Errorf("Failed to luksOpen Ceph volume '%s' (device %s) - %s", v.Name(), v.mappedDevicePath, err)
+			return "", err
+		}
+		defer stdin.Close()
+		if err := cmd.Start(); err != nil {
+			logrus.Errorf("Failed to luksOpen Ceph volume '%s' (device %s) - %s", v.Name(), v.mappedDevicePath, err)
+			return "", err
+		}
+
+		key, err := getLuksKey(v.Name())
+		if err != nil {
+			logrus.Errorf("Failed to luksOpen Ceph volume '%s' (device %s) - %s", v.Name(), v.mappedDevicePath, err)
+			return "", err
+		}
+
+		io.WriteString(stdin, key)
+		io.WriteString(stdin, "\n")
+		if err := cmd.Wait(); err != nil {
+			logrus.Errorf("Failed to luksOpen Ceph volume '%s' (device %s) - %s", v.Name(), v.mappedDevicePath, err)
+			return "", err
+		}
+		v.mappedLuksDevicePath = path.Join(LuksDevMapperPath, v.Name())
+	}
+
 	if fsType == "" {
+		//if fsType == "" {
 		cmd = exec.Command("mkfs.ext4", "-m0", "-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0,packed_meta_blocks=1", v.mappedDevicePath)
 		logrus.Infof("Creating ext4 filesystem in newly created Ceph volume '%s' (device %s)", v.Name(), v.mappedDevicePath)
 		if err := cmd.Run(); err != nil {
@@ -185,14 +224,18 @@ func (v *Volume) Mount(id string) (mappedDevicePath string, returnedError error)
 			return "", err
 		}
 	}
-	
+
 	fsckCmd, err := exec.Command("fsck", "-a", v.mappedDevicePath).Output()
 	if err != nil {
 		logrus.Errorf("Failed to check filesystem in %s - %s", v.Name(), err)
 		return "", err
 	}
 	logrus.Infof("Checked filesystem in %s: %s", v.Name(), fsckCmd)
-	
+
+	if fsType == criptoLUKS {
+		return v.mappedLuksDevicePath, nil
+	}
+
 	// The return value from this method will be passed to the container
 	return v.mappedDevicePath, nil
 }
@@ -203,6 +246,19 @@ func (v *Volume) Unmount(id string) error {
 
 	if err := v.release(); err != nil {
 		return err
+	}
+
+	fsType, err := utils.DeviceHasFilesystem(v.mappedDevicePath)
+	if err != nil {
+		return err
+	}
+
+	if fsType == "crypto_LUKS" {
+		cmd := exec.Command("cryptsetup", "luksClose", v.Name())
+		if err := cmd.Run(); err != nil {
+			logrus.Errorf("Failed to luksClose Ceph volume '%s' (device %s) - %s", v.Name(), v.mappedDevicePath, err)
+			return err
+		}
 	}
 	//if v.usedCount == 0 { // Even if the volume is attempted to be used multiple times, only the first use will actually succeed in mapping it
 	unmapCephVolume(v.name, v.mappedDevicePath)
@@ -235,4 +291,8 @@ func (v *Volume) release() error {
 	}
 	v.usedCount--
 	return nil
+}
+
+func getLuksKey(name string) (string, error) {
+	return name, nil
 }


### PR DESCRIPTION
Solves https://jira.medallia.com/browse/CIF-30

Tests:

1. Test mount ceph encrypted volume using docker

1.1. Manually create encrypted volume
```
rbd create lala-1 --size 16G
 sudo rbd map lala-1 
sudo cryptsetup luksFormat /dev/rbd0 # lala-1
cryptsetup luksOpen /dev/rbd0 lala-1 
mkfs.ext4 /dev/mapper/lala-1
mkdir /vagrant/data/lala-1 
mount /dev/mapper/lala-1 /vagrant/data/lala-1
echo "dog" > /vagrant/data/lala-1/cat
```

1.2. Mount volume with docker container
```
medallia@fib-r10-u08:~$ docker run -ti -v lala-1:/foo:ceph,rw ubuntu /bin/bash
root@90f91393252d:/# cat /foo/cat 
dog
```

2. Test can't mount same ceph encrypted volume with docker twice

2.1 Try to run second container while one is still running
```
medallia@fib-r10-u01:~$ docker run -ti -v lala-1:/foo:ceph,rw ubuntu /bin/bash
docker: Error response from daemon: Failed to map Ceph volume 'lala-1': exit status 1 - (2460) Map lala-1
(2460) Map lala-1 failed: image is being watched: watcher=10.112.10.34:0/1093050966 client.114105 cookie=8.
```

2.2 kill first container and then re-run

```
medallia@fib-r10-u01:~$ docker run -ti -v lala-1:/foo:ceph,rw ubuntu /bin/bash
root@ef23c13041e8:/# cat /foo/cat 
dog
```

3. hard power-cycle machine while docker container with encrypted volume is running and try to re-mount volume on docker container in another machine 

This works in FIB but I had to manually remove locks and watchers for the volume since FIB is not doing this automatically. Will test in Germany. 
